### PR TITLE
Updated Entities URLs to fix FTBFS in offline environment.

### DIFF
--- a/doc/C/gnumeric.xml
+++ b/doc/C/gnumeric.xml
@@ -47,17 +47,17 @@
 
   <!-- For mdash, hellip and friends -->
   <!ENTITY % isopub PUBLIC "ISO 8879:1986//ENTITIES Publishing//EN//XML"
-           "http://www.oasis-open.org/docbook/xml/4.5/ent/isopub.ent">
+           "http://www.w3.org/2003/entities/iso8879/isopub.ent">
   %isopub;
 
   <!-- For nbsp, pound, yen and friends -->
   <!ENTITY % isonum PUBLIC "ISO 8879:1986//ENTITIES Numeric and Special Graphic//EN//XML"
-           "http://www.oasis-open.org/docbook/xml/4.5/ent/isonum.ent">
+           "http://www.w3.org/2003/entities/iso8879/isonum.ent">
   %isonum;
 
   <!-- Character entity to provide greek letters in simulation chapter -->
   <!ENTITY % isogrk1 PUBLIC "ISO 8879:1986//ENTITIES Greek Letters//EN//XML"
-           "http://www.oasis-open.org/docbook/xml/4.5/ent/isogrk1.ent">
+           "http://www.w3.org/2003/entities/iso8879/isogrk1.ent">
   %isogrk1;
 
   <!ENTITY legal                SYSTEM "legal.xml">


### PR DESCRIPTION
 This commit set canonical URLs for Entities as they refer to themselves.

 Incorrect URLs cause FTBFS in offline build environment even when
 "w3c-sgml-lib" package is installed:

~~~~
Error: Could not parse document:
 connection refused ..//C/gnumeric.xml:51:  I/O  warning :  failed to load external entity "http://www.oasis-open.org/docbook/xml/4.5/ent/isopub.ent"
   %isopub;
           ^
  %isopub;
          ^
 connection refused ..//C/gnumeric.xml:56:  I/O  warning :  failed to load external entity "http://www.oasis-open.org/docbook/xml/4.5/ent/isonum.ent"
   %isonum;
           ^
  %isonum;
          ^
 connection refused ..//C/gnumeric.xml:61:  I/O  warning :  failed to load external entity "http://www.oasis-open.org/docbook/xml/4.5/ent/isogrk1.ent"
   %isogrk1;
            ^
~~~~

Signed-off-by: Dmitry Smirnov <onlyjob@member.fsf.org>